### PR TITLE
Fixes ustrcpy

### DIFF
--- a/zint_common.pas
+++ b/zint_common.pas
@@ -101,7 +101,7 @@ var
   len : NativeInt;
 begin
   len := strlen(source);
-  if len > 0 then
+//  if len > 0 then
     Move(Source[0], Target[0], Len * SizeOf(Char));
 
   target[len] := #0;
@@ -129,13 +129,12 @@ end;
 { Local replacement for strcpy() with uint8_t strings }
 procedure ustrcpy(var target : TArrayOfByte; const source : TArrayOfByte);
 var
-  {i,} len : NativeInt;
+  len : NativeInt;
 begin
   len := ustrlen(source);
-  Move(Source, Target, Len);
-//  for i := 0 to len - 1 do
-//    target[i] := source[i];
-  target[len] := 0;
+
+  target := Copy(Source);
+  target[len] := 0;   // Be sure we have zero terminal
 end;
 
 procedure ustrcpy(var ATarget: TArrayOfByte; const ASource : String);

--- a/zint_gs1.pas
+++ b/zint_gs1.pas
@@ -312,7 +312,7 @@ begin
     reduced[j] := #0;
 
 	{ the character '[' in the reduced string refers to the FNC1 character }
-	result := 0; exit;
+	result := 0;
 end;
 
 function ugs1_verify(symbol : zint_symbol; source : TArrayOfByte; src_len : Integer; var reduced : TArrayOfByte) : Integer;
@@ -322,15 +322,19 @@ var
 begin
   SetLength(temp, src_len + 5);
 	error_number := gs1_verify(symbol, source, src_len, temp);
-	if (error_number <> 0) then begin Result := error_number; exit; end;
-
-	if (strlen(temp) < src_len + 5) then
-  begin
-    ustrcpy(reduced, ArrayOfCharToArrayOfByte(temp));
-		Result := 0; exit;
+	if (error_number <> 0) then begin
+    Result := error_number;
+    exit;
   end;
+
+	if (strlen(temp) < src_len + 5) then begin
+    ustrcpy(reduced, ArrayOfCharToArrayOfByte(temp));
+		Result := 0;
+    exit;
+  end;
+
 	strcpy(symbol.errtxt, 'ugs1_verify overflow');
-	result := ZERROR_INVALID_DATA; exit;
+	result := ZERROR_INVALID_DATA;
 end;
 
 end.

--- a/zint_helper.pas
+++ b/zint_helper.pas
@@ -201,11 +201,7 @@ begin
 end;
 
 procedure Fill(var ADestination: TArrayOfChar; ACount: NativeInt; AChar: Char; AStartIndex: NativeInt);
-//var
-//  i : NativeInt;
 begin
-//  for i := AStartIndex to AStartIndex + ACount - 1 do
-//    ADestination[i] := AChar;
   FillChar(ADestination[AStartIndex], ACount, AChar);
 end;
 
@@ -226,11 +222,7 @@ begin
 end;
 
 procedure Fill(var ADestination: TArrayOfByte; ACount: NativeInt; AValue: Byte; AStartIndex: NativeInt);
-//var
-//  i : NativeInt;
 begin
-//  for i := AStartIndex to AStartIndex + ACount - 1 do
-//    ADestination[i] := AValue;
   FillChar(ADestination[AStartIndex], ACount, AValue);
 end;
 


### PR DESCRIPTION
Replaced move by copy for the ustrcpy proc from zint_common unit.
Seems to behave much better with the target parameter defined as var !
Some small refactoring, like removing exit as a last line of a proc...