### PR TITLE
Windows unit dependency was removed for another platforms.

### DIFF
--- a/zint_dotcode.pas
+++ b/zint_dotcode.pas
@@ -27,8 +27,14 @@ function dotCode(symbol : zint_symbol; source : TArrayOfByte; _length : Integer)
 implementation
 
 uses
-  SysUtils, Math, Windows, zint_reedsol, zint_common;
+  SysUtils, Math, {$IFDEF MSWINDOWS}Windows,{$ENDIF} zint_reedsol, zint_common;
 
+procedure OutputDebugString(const AMessage: string);
+begin
+{$IFDEF MSWINDOWS}
+  Windows.OutputDebugString(AMessage);
+{$ENDIF}
+end;
 
 {* DotCode symbol character dot patterns, from Annex C *}
 const


### PR DESCRIPTION
Windows unit is not available on another platforms (Android, iOS, macOS). I have added code-defines for output debugging messages.